### PR TITLE
llm proxy updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ logs.txt
 telemetry.log
 sincedb_telemetry.log
 logstash
+provision.env
+llm-proxy.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-# syntax=docker/dockerfile:1
-
 FROM node:18-alpine
 ENV NODE_ENV=production
-ENV ELASTIC_APM_SERVICE_NAME=node-llm-proxy
+ENV ELASTIC_APM_SERVICE_NAME=llm-proxy
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ and then
 bash runDocker.sh
 ```
 
+### to deploy to Google Cloud Run
+
+```bash
+bash deploy.sh
+```
+
 ### to test
 
 use the api by sending queries to

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,22 @@
+# uncomment to download latest version of provisioning vars
+#gcloud secrets versions access latest --secret=llm_proxy_provision > provision.env
+source provision.env
+
+gcloud auth configure-docker $GCP_REGION-docker.pkg.dev
+
+deploy_app() {
+    docker build --platform linux/amd64 -t $GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/notebook-workshop/llm-proxy --file Dockerfile .
+    docker push $GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/notebook-workshop/llm-proxy
+
+    sed "s,"'$GCP_PROJECT_ID'",$GCP_PROJECT_ID,g" deploy/llm-proxy.yaml.tmpl > llm-proxy.yaml
+    sed -i "" "s,"'$GCP_REGION'",$GCP_REGION,g" llm-proxy.yaml
+    sed -i "" "s,"'$GCP_LABELS_DIVISION'",$GCP_LABELS_DIVISION,g" llm-proxy.yaml
+    sed -i "" "s,"'$GCP_LABELS_ORG'",$GCP_LABELS_ORG,g" llm-proxy.yaml
+    sed -i "" "s,"'$GCP_LABELS_TEAM'",$GCP_LABELS_TEAM,g" llm-proxy.yaml
+    sed -i "" "s,"'$BASE_URL'",$BASE_URL,g" llm-proxy.yaml
+    gcloud run services replace llm-proxy.yaml
+    rm -rf llm-proxy.yaml
+}
+
+deploy_app
+

--- a/deploy/llm-proxy.yaml.tmpl
+++ b/deploy/llm-proxy.yaml.tmpl
@@ -1,0 +1,69 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: llm-proxy
+  labels:
+    division: $GCP_LABELS_DIVISION
+    org: $GCP_LABELS_ORG
+    team: $GCP_LABELS_TEAM
+    cloud.googleapis.com/location: $GCP_REGION
+  annotations:
+    run.googleapis.com/ingress: all
+    run.googleapis.com/ingress-status: all
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/maxScale: '2'
+        run.googleapis.com/startup-cpu-boost: 'true'
+    spec:
+      containers:
+      - image: $GCP_REGION-docker.pkg.dev/$GCP_PROJECT_ID/notebook-workshop/llm-proxy
+        ports:
+        - name: http1
+          containerPort: 3000
+        env:
+        - name: BASE_URL
+          value: $BASE_URL
+        - name: AZURE_LLM_DEPLOYMENTS
+          valueFrom:
+            secretKeyRef:
+              key: 'latest'
+              name: llm_proxy_endpoints
+        - name: SALT
+          valueFrom:
+            secretKeyRef:
+              key: 'latest'
+              name: llm_proxy_salt
+        - name: ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: 'latest'
+              name: llm_proxy_admin_password
+        - name: ELASTIC_APM_SERVER_URL
+          valueFrom:
+            secretKeyRef:
+              key: 'latest'
+              name: llm_proxy_apm_url
+        - name: ELASTIC_APM_SECRET_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: 'latest'
+              name: llm_proxy_apm_token
+        livenessProbe:
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+          periodSeconds: 5
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 3000
+        startupProbe:
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 10
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 3000
+      serviceAccountName: 1059491012611-compute@developer.gserviceaccount.com

--- a/functions.js
+++ b/functions.js
@@ -78,7 +78,11 @@ const VALID_JWT = "valid";
 const CLOCK_TOLERANCE = 86400; // allow tokens to be valid up to 1 day after expiration
 async function checkAuthJwt(authKey) {
     if (authKey.toLowerCase().startsWith("bearer "))
-        authKey = authKey.slice("bearer ".length);
+        authKey = authKey.slice("bearer ".length)
+    // our notebooks may append a hash after the JWT (for rate-limiting); ignore it here
+    const spacePos = authKey.indexOf(' ')
+    if (spacePos != -1)
+        authKey = authKey.slice(0, spacePos)
     try {
         const {payload, protectedHeader} = await jose.jwtVerify(authKey, new TextEncoder().encode(JWT_SECRET), {"clockTolerance": CLOCK_TOLERANCE});
         console.log({'validated key for workshop:': payload.jti});
@@ -100,10 +104,8 @@ async function checkAuthJwt(authKey) {
                 return {'status': EXPIRED_JWT}
             }
         }
-        else {
-            console.log('unable to validate key:', err)
-            return {'status': INVALID_JWT}
-        }
+        console.log('unable to validate key:', err)
+        return {'status': INVALID_JWT}
     }
 }
 

--- a/test.js
+++ b/test.js
@@ -33,6 +33,14 @@ async function static_tests() {
         throw "jwt auth failed 3";
     }
 
+    if (!await checkAuth(jwt + " abc123")) {
+        throw "jwt auth failed 3";
+    }
+
+    if (!await checkAuth("Bearer " + jwt + " abc123")) {
+        throw "jwt auth failed 3";
+    }
+
     jwt = await generateJwt(Date.parse("1975-05-11"), "abc123");
     if (await checkAuth("Bearer " + jwt)) {
         throw "jwt auth failed 4";


### PR DESCRIPTION
hey!

this is a set of commits which:
1) bring parity to JWT auth (with respect to the original auth method) which allows for a per-user hash in the bearer token to allow for per-user, per-session rate limiting
2) properly emits an exception if the JWT is improperly formatted
3) adds deployment scripts to make it easy to re-deploy to Google Cloud Run
4) changes the service.name to 'llm-proxy' to permit better integration in APM with other components